### PR TITLE
Fixes for a new release

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,11 +4,11 @@
     "node": true
   },
   "rules": {
-    "no-multi-spaces": false,
-    "no-multi-str": false,
+    "no-multi-spaces": 0,
+    "no-multi-str": 0,
     "quotes": [1, "single"],
-    "no-underscore-dangle": false,
-    "comma-dangle": false,
+    "no-underscore-dangle": 0,
+    "comma-dangle": 0,
     "strict": 0,
     "react/jsx-quotes": 1,
     "react/jsx-no-undef": 1,

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -2,7 +2,7 @@ var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var webpack = require('webpack');
 
 module.exports = {
-  entry: './index.jsx',
+  entry: __dirname + '/index.jsx',
   output: {
     path: 'assets',
     filename: 'bundle.js',

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "babel-core": "^5.2.15",
     "babel-loader": "^5.0.0",
     "css-loader": "^0.12.0",
-    "eslint": "^0.20.0",
+    "eslint": "^0.23.0",
     "eslint-plugin-react": "^2.2.0",
     "extract-text-webpack-plugin": "^0.7.1",
     "grunt": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "jquery": "^2.1.4"
   },
   "peerDependencies": {
-    "react": ">= 0.12.0, < 0.14.0",
+    "react": ">= 0.12.0 || =0.14.0-alpha3",
     "jquery": "^2.1.4"
   },
   "devDependencies": {
@@ -47,8 +47,7 @@
     "grunt-release": "^0.12.0",
     "gruntify-eslint": "^0.1.0",
     "load-grunt-tasks": "^3.1.0",
-    "react": ">= 0.12.0, < 0.14.0",
-    "react-tools": "^0.13.2",
+    "react": ">= 0.12.0",
     "style-loader": "^0.12.1",
     "webpack": "^1.8.11"
   }

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
   },
   "dependencies": {
     "cropper": "^0.9.3",
-    "jquery": "^2.1.4"
+    "jquery": "^1.11.3 || ^2.1.4"
   },
   "peerDependencies": {
     "react": ">= 0.12.0 || =0.14.0-alpha3",
-    "jquery": "^2.1.4"
+    "jquery": "^1.11.3 || ^2.1.4"
   },
   "devDependencies": {
     "babel-core": "^5.2.15",

--- a/src/react-cropper.jsx
+++ b/src/react-cropper.jsx
@@ -148,7 +148,7 @@ var Cropper = React.createClass({
 
   render() {
     return (
-      <div {...this.props}>
+      <div {...this.props} src={null}>
         <img
           crossOrigin='anonymous'
           ref='img'

--- a/src/react-cropper.jsx
+++ b/src/react-cropper.jsx
@@ -66,6 +66,15 @@ var Cropper = React.createClass({
     }
   },
 
+  componentWillUnmount: function() {
+    if(this.$img) {
+      // Destroy the cropper, this makes sure events such as resize are cleaned up and do not leak
+      this.$img.cropper('destroy');
+      // While we're at it remove our reference to the jQuery instance
+      delete this.$img;
+    }
+  },
+
   move(offsetX, offsetY){
     return this.$img.cropper('move', offsetX, offsetY);
   },
@@ -96,10 +105,6 @@ var Cropper = React.createClass({
 
   replace(url){
     return this.$img.cropper('replace', url);
-  },
-
-  destroy(){
-    return this.$img.cropper('destroy');
   },
 
   getData(){


### PR DESCRIPTION
I've made a bunch of fixes that could be packaged up into a new release.

- I fixed the example so it actually compiles using `npm run-script example`
- Fixed a bug where the <div> gets a src=""
- Added support for 0.14 and dropped the unused react-tools.
- Added support for the 1.x.x. series of jQuery (the currently maintained series supporting older browsers)
- Upgraded eslint
- And I fixed a memory leak in the component

Half of these are necessary for me to be able to use react-cropper.