### PR TITLE
Update to use 0.14.0-beta3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "cropper": "^0.10.0"
   },
   "peerDependencies": {
-    "react": ">= 0.12.0 || =0.14.0-alpha3",
+    "react": "=0.14.0-beta3",
+    "react-dom": "=0.14.0-beta3",
     "jquery": "^1.11.3 || ^2.1.4"
   },
   "devDependencies": {

--- a/src/react-cropper.js
+++ b/src/react-cropper.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import $ from 'jquery';
 import 'cropper';
 import 'cropper/dist/cropper.css';
@@ -61,7 +62,7 @@ const Cropper = React.createClass({
         options[prop] = this.props[prop];
       }
     }
-    this.$img = $(React.findDOMNode(this.refs.img));
+    this.$img = $(ReactDOM.findDOMNode(this.refs.img));
     this.$img.cropper(options);
   },
 


### PR DESCRIPTION
This is a breaking change that drops support for 0.13 and exclusively supports 0.14 and the new react-dom package.

This may make the basis for a new major version of react-cropper in the future when 0.14 is released. I don't expect it to be merged into the current master, as it currently only uses beta3.

However, because react-cropper cannot be installed via git+https:// with npm. It would be nice to have a non-stable npm release tag that supports 0.14.0-beta3.