### PR TITLE
Support React version 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
   },
   "dependencies": {
     "cropperjs": "^0.5.0",
-    "react-dom": "^0.14.3"
+    "react-dom": "^0.14.3 || ^15.0.0"
   },
   "peerDependencies": {
-    "react": "^0.14.6"
+    "react": "^0.14.6 || ^15.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",
@@ -46,8 +46,8 @@
     "eslint-config-airbnb": "^6.1.0",
     "eslint-plugin-react": "^4.2.1",
     "extract-text-webpack-plugin": "^0.8.2",
-    "react": "^0.14.7",
-    "react-dom": "^0.14.3",
+    "react": "^0.14.7 || ^15.0.0",
+    "react-dom": "^0.14.3 || ^15.0.0",
     "react-hot-loader": "^1.3.0",
     "style-loader": "^0.12.3",
     "webpack": "^1.12.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-cropper",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Cropper as React components",
   "main": "dist/react-cropper.js",
   "scripts": {


### PR DESCRIPTION
Hi there,

Just bumping the dependency version numbers so I can use react-cropper with the latest release of React. There doesn't seem to be any other issues with the latest version other than their change in versioning style.