### PR TITLE
Adds babel-plugin-transform-object-assign for IE support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "babel-core": "^6.7.6",
     "babel-eslint": "^6.0.2",
     "babel-loader": "^6.2.4",
+    "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "css-loader": "^0.17.0",
@@ -59,6 +60,7 @@
       "react",
       "es2015"
     ],
+    "plugins": ["transform-object-assign"],
     "ignore": [
       "dist/**/*.js",
       "webpack.config.js",


### PR DESCRIPTION
You're currently using `Object.assign` to merge your default options with the properties passed to the component in `componentDidMount` but it doesn't seem like it's being replaced in the build. All versions of IE are lacking `Object.assign` so it throws and error. This pull request will resolve the issue just by adding a plugin for babel.