### PR TITLE
Require Cropper library in `componentDidMount` method

### DIFF
--- a/src/react-cropper.jsx
+++ b/src/react-cropper.jsx
@@ -1,6 +1,4 @@
 import React, { Component, PropTypes } from 'react';
-import Cropper from 'cropperjs';
-
 import ReactDOM from 'react-dom';
 
 const optionProps = [
@@ -56,6 +54,7 @@ class ReactCropper extends Component {
       Object.assign({}, prevOptions, { [propKey]: this.props[propKey] })
     , {});
 
+    const Cropper = require('cropperjs');
     this.cropper = new Cropper(this.img, options);
   }
 


### PR DESCRIPTION
When build `react-cropper` for server bundle by `webpack`, I've got:

```
ReferenceError: window is not defined
    at Object.defineProperty.value (*/node_modules/cropperjs/dist/cropper.js:1219:18)
```

I propose this refactoring according sokra (creator of webpack) comment:
https://github.com/webpack/react-starter/issues/37#issuecomment-93943419