### PR TITLE
Update deprecated React.PropTypes to standalone prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "url": "https://github.com/roadmanfong/react-cropper.git"
   },
   "dependencies": {
-    "cropperjs": "^0.8.0"
+    "cropperjs": "^0.8.0",
+    "prop-types": "^15.5.8"
   },
   "peerDependencies": {
     "react": "^15.0.0",

--- a/src/react-cropper.jsx
+++ b/src/react-cropper.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 import ReactDOM from 'react-dom';
 


### PR DESCRIPTION
See React v15.5 documentation/post for more information:

https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes

https://github.com/reactjs/prop-types