### PR TITLE
Fixes#39 - Remove Crop from Unchangeable Props

### DIFF
--- a/src/react-cropper.jsx
+++ b/src/react-cropper.jsx
@@ -7,6 +7,7 @@ const optionProps = [
   'dragMode',
   'aspectRatio',
   'data',
+  'crop',
   // unchangeable props start from here
   'viewMode',
   'preview',
@@ -41,11 +42,10 @@ const optionProps = [
   'cropstart',
   'cropmove',
   'cropend',
-  'crop',
   'zoom',
 ];
 
-const unchangeableProps = optionProps.slice(3);
+const unchangeableProps = optionProps.slice(4);
 
 class ReactCropper extends Component {
 


### PR DESCRIPTION
Thanks very much for the great project.

As per issue #39 (https://github.com/roadmanfong/react-cropper/issues/39) crop is flagged with an error message as an unchangeable prop.

However, there are cases where this probably should not apply. In my case I wrap the crop prop in a debounce function which triggers this error message.