### PR TITLE
Add UNSAFE lifecycle to remove warnings #121

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,10 @@
   "rules": {
     "react/no-unused-prop-types": 0,
     "react/require-default-props": 0,
-    "react/jsx-filename-extension": 0
+    "react/jsx-filename-extension": 0,
+    "camelcase": [
+      0,
+      {"allow": ["^UNSAFE_"]}
+    ]
   }
 }

--- a/src/react-cropper.js
+++ b/src/react-cropper.js
@@ -57,7 +57,7 @@ class ReactCropper extends Component {
     this.cropper = new Cropper(this.img, options);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.src !== this.props.src) {
       this.cropper.reset().clear().replace(nextProps.src);
     }


### PR DESCRIPTION
Just add **UNSAFE** lifecycle to remove React 16.9 warnings.