### PR TITLE
update zoomTo() include pivot point

### DIFF
--- a/src/react-cropper.js
+++ b/src/react-cropper.js
@@ -184,8 +184,8 @@ class ReactCropper extends Component {
     return this.cropper.zoom(ratio);
   }
 
-  zoomTo(ratio) {
-    return this.cropper.zoomTo(ratio);
+  zoomTo(ratio, pivot = null) {
+    return this.cropper.zoomTo(ratio, pivot);
   }
 
   rotate(degree) {


### PR DESCRIPTION
Cropperjs (version 1.3.3) zoomTo was overloaded with a pivot point (pivot = {x:num, y:num}). Current Build of cropperjs is 1.5.5 and this functionality does not exist in the current React-Cropper code base